### PR TITLE
Focus fixes, fix Alt-F4

### DIFF
--- a/NanaGet/WinMain.cpp
+++ b/NanaGet/WinMain.cpp
@@ -26,9 +26,11 @@
 namespace winrt
 {
     using Windows::UI::Xaml::ElementTheme;
+    using Windows::UI::Xaml::FocusState;
     using Windows::UI::Xaml::FrameworkElement;
     using Windows::UI::Xaml::UIElement;
     using Windows::UI::Xaml::Hosting::DesktopWindowXamlSource;
+    using Windows::UI::Xaml::Hosting::DesktopWindowXamlSourceTakeFocusRequestedEventArgs;
     using Windows::UI::Xaml::Media::VisualTreeHelper;
 }
 
@@ -149,6 +151,13 @@ int NanaGet::MainWindow::OnCreate(
     HWND XamlWindowHandle = nullptr;
     winrt::check_hresult(
         XamlSourceNative->get_WindowHandle(&XamlWindowHandle));
+
+    // When focus is moving out from XAML island, move it back in again.
+    this->m_XamlSource.TakeFocusRequested(
+        [this](winrt::DesktopWindowXamlSource sender,
+            winrt::DesktopWindowXamlSourceTakeFocusRequestedEventArgs args) {
+            this->m_MainPage.Focus(winrt::FocusState::Programmatic);
+        });
 
     // Focus on XAML Island host window for Acrylic brush support.
     ::SetFocus(XamlWindowHandle);

--- a/NanaGet/WinMain.cpp
+++ b/NanaGet/WinMain.cpp
@@ -52,8 +52,6 @@ namespace NanaGet
 {
     class MainWindow : public ATL::CWindowImpl<MainWindow>
     {
-        friend class XamlIslandHostMessageFilter;
-
     public:
 
         DECLARE_WND_CLASS(L"NanaGetMainWindow")

--- a/NanaGet/WinMain.cpp
+++ b/NanaGet/WinMain.cpp
@@ -69,7 +69,8 @@ namespace NanaGet
             MSG_WM_DESTROY(OnDestroy)           
         END_MSG_MAP()
 
-        virtual BOOL PreTranslateMessage(MSG* pMsg);
+        virtual BOOL PreTranslateMessage(
+            MSG* pMsg);
 
         int OnCreate(
             LPCREATESTRUCT lpCreateStruct);
@@ -110,8 +111,9 @@ namespace NanaGet
     };
 }
 
-BOOL NanaGet::MainWindow::PreTranslateMessage(MSG* pMsg) {
-
+BOOL NanaGet::MainWindow::PreTranslateMessage(
+    MSG* pMsg)
+{
     // Workaround for capturing Alt+F4 in applications with XAML Islands.
     // Reference: https://github.com/microsoft/microsoft-ui-xaml/issues/2408
     if (pMsg->message == WM_SYSKEYDOWN && pMsg->wParam == VK_F4)


### PR DESCRIPTION
- Fix Alt-F4 (#7), reference: https://github.com/microsoft/microsoft-ui-xaml/issues/2408
- Move focus back to the first control in XAML island when tabbing out of the island, so that the focus does not get lost when you hold down tab.